### PR TITLE
feature/determine-scraper-strategy-and-test-legistar

### DIFF
--- a/.github/workflows/instance-configuration-validation-bot.yml
+++ b/.github/workflows/instance-configuration-validation-bot.yml
@@ -42,10 +42,11 @@ jobs:
 
             :thought_balloon: Validating planned instance maintainer
             :thought_balloon: Validating planned instance repository name
+            :thought_balloon: Determining event scraper strategy and optionally testing Legistar
 
             #### All Cookiecutter Parameters
 
-            :thought_balloon:
+            :thought_balloon: Generating...
             
             _This comment was written by a bot!_
       
@@ -67,10 +68,11 @@ jobs:
 
             :thought_balloon: Validating planned instance maintainer
             :thought_balloon: Validating planned instance repository name
+            :thought_balloon: Determining event scraper strategy and optionally testing Legistar
 
             #### All Cookiecutter Parameters
 
-            :thought_balloon:
+            :thought_balloon: Generating...
             
             _This comment was written by a bot!_
 

--- a/.github/workflows/scripts/validate-form.py
+++ b/.github/workflows/scripts/validate-form.py
@@ -266,20 +266,21 @@ def validate_form(issue_content_file: str) -> None:
             )
 
     # Handle bad / mis-parametrized legistar info
-    if (
-        form_values[LEGISTAR_CLIENT_ID] is not None
-        and form_values[LEGISTAR_CLIENT_TIMEZONE] is None
-    ):
-        legistar_response = (
-            ":x: You provided a Legistar Client Id but no Timezone. "
-            "**Timezone is required** for Legistar scraping."
-        )
-    else:
-        legistar_response = (
-            ":thought_balloon: **You didn't provided Legistar Client information**, "
-            "please note that you will be required to write an entirely custom event "
-            "scraper after your instance is deployed."
-        )
+    if legistar_response is not None:
+        if (
+            form_values[LEGISTAR_CLIENT_ID] is not None
+            and form_values[LEGISTAR_CLIENT_TIMEZONE] is None
+        ):
+            legistar_response = (
+                ":x: You provided a Legistar Client Id but no Timezone. "
+                "**Timezone is required** for Legistar scraping."
+            )
+        else:
+            legistar_response = (
+                ":thought_balloon: **You didn't provided Legistar Client "
+                "information**, please note that you will be required to write "
+                "an entirely custom event scraper after your instance is deployed."
+            )
 
     # Construct message content
     if planned_maintainer_exists:

--- a/.github/workflows/scripts/validate-form.py
+++ b/.github/workflows/scripts/validate-form.py
@@ -257,6 +257,14 @@ def validate_form(issue_content_file: str) -> None:
                 f"scraper that inherits from our base to resolve this issue."
             )
 
+        except Exception:
+            legistar_response = (
+                f":x: Something went wrong during Legistar client data validation. "
+                f"A [cdp-scrapers]"
+                f"(https://github.com/{COUNCIL_DATA_PROJECT}/cdp-scrapers) maintainer "
+                f"should look into the logs for this bug. Sorry about this!"
+            )
+
     # Handle bad / mis-parametrized legistar info
     if (
         form_values[LEGISTAR_CLIENT_ID] is not None
@@ -264,11 +272,11 @@ def validate_form(issue_content_file: str) -> None:
     ):
         legistar_response = (
             ":x: You provided a Legistar Client Id but no Timezone. "
-            "Timezone is required for Legistar scraping."
+            "**Timezone is required** for Legistar scraping."
         )
     else:
         legistar_response = (
-            ":thought_balloon: You didn't provided Legistar Client information, "
+            ":thought_balloon: **You didn't provided Legistar Client information**, "
             "please note that you will be required to write an entirely custom event "
             "scraper after your instance is deployed."
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[flake8]
+exclude = 
+	docs/
+ignore = 
+	E203
+	E402
+	W291
+	W503
+max-line-length = 88


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #30 

### Description of Changes

_Include a description of the proposed changes._

Adds functionality to determine the planned scraper strategy for the user (either write their own custom scraper after, or before, the deployment, or use Legistar (which could also be custom). Along the way it tests all the various routes the scraper could take.

Minor flake8 changes because I was getting annoyed at my editor.

Example: 
![image](https://user-images.githubusercontent.com/17132317/129530509-fd0576d7-1e73-4b8e-814e-42f13ac20a85.png)

Once again, please see [my fork's issues for testing this functionality](https://github.com/JacksonMaxfield/cookiecutter-cdp-deployment/issues/new/choose).

I personally tested it with:
- [x] no legistar provided
- [x] legistar with no timezone
- [x] seattle
- [x] king county
- [x] oakland
- [x] chicago
- [x] "doesnotexist"

There are the two routes that I don't know how to test with a real legistar instance
* everything is in the legistar instance and so its just the easiest "push button press" ever
* the video is present but not all required minimum data (which would be _incredibly odd_ imo)

---

Also tagging @dphoria for input on scraper design / impl here.