### PR TITLE
docs/update-bot-text

### DIFF
--- a/.github/workflows/deployment-management-bot.yml
+++ b/.github/workflows/deployment-management-bot.yml
@@ -293,15 +293,15 @@ jobs:
           body: |
             ## Deployment Status
 
-            :tada: :tada: **Completed** :tada: :tada:
+            :tada: :tada: **Repository Created** :tada: :tada:
             
             A new CouncilDataProject Instance Repository was created ([${{ fromJSON(steps.generation-options.outputs.content).repository_path }}](${{ fromJSON(steps.cookiecutter-options.outputs.options).hosting_github_url }})), external collaborator added (@${{ fromJSON(steps.generation-options.outputs.content).maintainer_name }}), and cookiecutter files generated and pushed to repository.
 
-            The instance should be setting itself up right now. See [the instance's GitHub Action job history](${{ fromJSON(steps.cookiecutter-options.outputs.options).hosting_github_url }}/actions) for more details as to progress of deployment setup.
+            The instance is setting itself up right now and the process will take around 10 minutes to complete. Once completed, a CDP maintainer will comment on this issue with your instance's website link. See [the instance's GitHub Action job history](${{ fromJSON(steps.cookiecutter-options.outputs.options).hosting_github_url }}/actions) for more details on the deployment setup progress.
+
+            Your CDP instance will be populated with data within 6 hours of website creation.
 
             At any point in the future if you would like to destroy this instance, please just add a comment to this thread and a maintainer will help you.
-
-            The remaining setup steps take an additional ~10 minutes to complete. A CDP maintainer will comment on this issue when the instance has been fully deployed.
 
             ---
 
@@ -337,6 +337,7 @@ jobs:
                   }
                   ```
             * [ ] Enable [GitHub Pages](${{ fromJSON(steps.cookiecutter-options.outputs.options).hosting_github_url }}/settings/pages)
+            * [ ] Comment on this issue with "Deployment Status - Complete" and the instance URL
 
             ##### Deletion Steps (Future Reference)
             

--- a/.github/workflows/instance-configuration-validation-bot.yml
+++ b/.github/workflows/instance-configuration-validation-bot.yml
@@ -158,11 +158,11 @@ jobs:
 
             #### Steps for Internal CDP Team
 
-            Prior to triggering this deployment:
+            To proceed with the deployment process, please do the following:
 
-            * [ ] Run `make login` and login to the CDP gcloud and pulumi accounts
-            * [ ] Run `make init project=${{ steps.municipality-slug.outputs.infra_slug }}`
-            * [ ] Comment "/cdp-deploy" and follow the rest of the instructions
+            * [ ] Run `make login` in cdp-backend/dev-infrastructure and login to the CDP gcloud and pulumi accounts
+            * [ ] Run `make init project=${{ steps.municipality-slug.outputs.infra_slug }}` in cdp-backend/dev-infrastructure
+            * [ ] Comment "/cdp-deploy" on this issue and follow the rest of the instructions
 
             More details on the `make` commands can be found in [cdp-backend](https://github.com/CouncilDataProject/cdp-backend/tree/main/dev-infrastructure).
             


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #45 

### Description of Changes

Text changes for the comments created during the CDP deployment process for greater user clarity

Bot 1 comment changes

- "Prior to triggering this deployment" -> "To proceed with the deployment process, please do the following"
- Add "in cdp-backend/dev-infrastructure" to the commands that must be run there
- 'Comment "/cdp-deploy"' -> 'Comment "/cdp-deploy" on this issue'

Bot 2 comment changes

- adding this to the description: "The instance is setting itself up right now and the process will take around 10 minutes to complete. Once completed, a CDP maintainer will comment on this issue with your instance's website link. See (link) for more details on the deployment setup progress. Your CDP instance will be populated with data within 6 hours of website creation."
- "Deployment Status - Completed" -> "Deployment Status - Repository Created"
- adding a step in Final Steps saying to manually add a comment with "Deployment Status - Completed" and the instance link when it is fully set up
