### PR TITLE
documentation/fix-README-command-for-project-setup

### DIFF
--- a/{{ cookiecutter.hosting_github_repo_name }}/SETUP/README.md
+++ b/{{ cookiecutter.hosting_github_repo_name }}/SETUP/README.md
@@ -104,7 +104,7 @@ There are additional tasks required after generating this repository.
     This step should be run while within the `SETUP` directory (`cd SETUP`)
 
     ```bash
-    just setup {{ cookiecutter.infrastructure_slug }} --region={{ cookiecutter.firestore_region }}
+    just setup {{ cookiecutter.infrastructure_slug }} {{ cookiecutter.firestore_region }}
     ```
 
 1.  Initial Firebase Storage.

--- a/{{ cookiecutter.hosting_github_repo_name }}/SETUP/README.md
+++ b/{{ cookiecutter.hosting_github_repo_name }}/SETUP/README.md
@@ -104,7 +104,7 @@ There are additional tasks required after generating this repository.
     This step should be run while within the `SETUP` directory (`cd SETUP`)
 
     ```bash
-    just setup {{ cookiecutter.firestore_region }}
+    just setup {{ cookiecutter.infrastructure_slug }} --region={{ cookiecutter.firestore_region }}
     ```
 
 1.  Initial Firebase Storage.


### PR DESCRIPTION
There is an erroneous setup command in the README that causes a confusing permission failure.

https://councildataproject.slack.com/archives/CMMNC8Y7P/p1662755102756549