### PR TITLE
Add Retry When Creating CML Runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ You can also see an example generated repository and the full steps listed
 | firestore_region               | The desired region to host the firestore instance. ([Firestore docs](https://firebase.google.com/docs/firestore/locations))                 | us-west1                                       | europe-central2                                   |
 | event_gather_timedelta_lookback_days               | The number of days to look back from the current date every time the event scraper runs.                  | 2                                       | 6                                   |
 | event_gather_cron               | The event gather CRON configuration. ([GitHub Actions CRON Details](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule))                 | 26 0,6,12,18 * * *                                       | 17 3,9,15,21 * * *                                   |
+| event_gather_runner_timeout_minutes | Minutes to wait before creating a CML runner attempt will fail. | 15 | 16 |
+| event_gather_runner_max_attempts | Number of times to attempt to create a CML runner. | 8 | 36 |
+| event_gather_runner_retry_wait_seconds | Number of seconds to wait between CML runner create attempts. | 600 | 600 |
 
 ### Things to Know
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ You can also see an example generated repository and the full steps listed
 | event_gather_timedelta_lookback_days               | The number of days to look back from the current date every time the event scraper runs.                  | 2                                       | 6                                   |
 | event_gather_cron               | The event gather CRON configuration. ([GitHub Actions CRON Details](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule))                 | 26 0,6,12,18 * * *                                       | 17 3,9,15,21 * * *                                   |
 | event_gather_runner_timeout_minutes | Minutes to wait before creating a CML runner attempt will fail. | 15 | 16 |
-| event_gather_runner_max_attempts | Number of times to attempt to create a CML runner. | 8 | 36 |
+| event_gather_runner_max_attempts | Number of times to attempt to create a CML runner. | 4 | 36 |
 | event_gather_runner_retry_wait_seconds | Number of seconds to wait between CML runner create attempts. | 600 | 600 |
 
 ### Things to Know

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -50,5 +50,8 @@
     "_extensions": [
         "cookiecutter.extensions.RandomStringExtension",
         "local_extensions.RandomIntegerExtension"
-    ]
+    ],
+    "event_gather_runner_timeout_minutes": 15,
+    "event_gather_runner_max_attempts": 8,
+    "event_gather_runner_retry_wait_seconds": 600
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -52,6 +52,6 @@
         "local_extensions.RandomIntegerExtension"
     ],
     "event_gather_runner_timeout_minutes": 15,
-    "event_gather_runner_max_attempts": 8,
+    "event_gather_runner_max_attempts": 4,
     "event_gather_runner_retry_wait_seconds": 600
 }

--- a/{{ cookiecutter.hosting_github_repo_name }}/.github/workflows/event-gather-pipeline.yml
+++ b/{{ cookiecutter.hosting_github_repo_name }}/.github/workflows/event-gather-pipeline.yml
@@ -29,19 +29,24 @@ jobs:
       - name: Setup CML
         uses: iterative/setup-cml@v1
       - name: Create Runner
+        uses: nick-fields/retry@v2
         env:
           REPO_TOKEN: {% raw %}${{ secrets.PERSONAL_ACCESS_TOKEN }}{% endraw %}
           GOOGLE_APPLICATION_CREDENTIALS_DATA: {% raw %}${{ secrets.GOOGLE_CREDENTIALS }}{% endraw %}
-        run: |
-          cml runner \
-            --single \
-            --labels=gcp-cdp-runner \
-            --cloud=gcp \
-            --cloud-region=us-central1-f \
-            --cloud-type=n1-standard-4 \
-            --cloud-gpu=nvidia-tesla-t4 \
-            --cloud-hdd-size=30 \
-            --idle-timeout=600
+        with:
+          timeout_minutes: {{ cookiecutter.event_gather_runner_timeout_minutes }}
+          max_attempts: {{ cookiecutter.event_gather_runner_max_attempts }}
+          retry_wait_seconds: {{ cookiecutter.event_gather_runner_retry_wait_seconds }}
+          command: |
+            cml runner \
+              --single \
+              --labels=gcp-cdp-runner \
+              --cloud=gcp \
+              --cloud-region=us-central1-f \
+              --cloud-type=n1-standard-4 \
+              --cloud-gpu=nvidia-tesla-t4 \
+              --cloud-hdd-size=30 \
+              --idle-timeout=600 \
 
   process-events:
     needs: [deploy-runner-on-gcp]
@@ -55,7 +60,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-    
+
     - name: Check GPU Drivers
       run: |
         nvidia-smi
@@ -92,7 +97,7 @@ jobs:
       run: |
         cd python/
         run_cdp_event_gather event-gather-config.json
-    
+
     - name: Gather and Process Requested Events - Manual
       if: {% raw %}${{ github.event_name == 'workflow_dispatch' }}{% endraw %}
       run: |

--- a/{{ cookiecutter.hosting_github_repo_name }}/cookiecutter.yaml
+++ b/{{ cookiecutter.hosting_github_repo_name }}/cookiecutter.yaml
@@ -15,3 +15,6 @@ default_context:
     event_gather_cron: "{{ cookiecutter.event_gather_cron }}"
     enable_clipping: "{{ cookiecutter.enable_clipping }}"
     speech_to_text_model_version: "{{ cookiecutter.speech_to_text_model_version }}"
+    event_gather_runner_timeout_minutes: "{{ cookiecutter.event_gather_runner_timeout_minutes }}"
+    event_gather_runner_max_attempts: "{{ cookiecutter.event_gather_runner_max_attempts }}"
+    event_gather_runner_retry_wait_seconds: "{{ cookiecutter.event_gather_runner_retry_wait_seconds }}"


### PR DESCRIPTION
### Description of Changes

- Since cdp-backend v4 we now use CML runner to create a compute instance on Google Cloud to run event_gather task. The CML runner requires GPU resources and can fail if no resources are available.
- Insead of one-shot of the run and fail (CML _does_ have some retry/timeout internally, but FWICT this is not configurable beyond `idle-timeout`.) use [nick-fields/retry@v2](https://github.com/nick-fields/retry) to implement retry wth constant backoff when creating the CML runner.
- Set default values in cookiecutter template (total of 3.3h):
  - `event_gather_runner_timeout_minutes`: 15
  - `event_gather_runner_max_attempts`: 8
  - `event_gather_runner_retry_wait_seconds`: 600