### PR TITLE
#143: changing cml runner syntax to multi-line, single-command

### DIFF
--- a/{{ cookiecutter.hosting_github_repo_name }}/.github/workflows/event-gather-pipeline.yml
+++ b/{{ cookiecutter.hosting_github_repo_name }}/.github/workflows/event-gather-pipeline.yml
@@ -37,7 +37,7 @@ jobs:
           timeout_minutes: {{ cookiecutter.event_gather_runner_timeout_minutes }}
           max_attempts: {{ cookiecutter.event_gather_runner_max_attempts }}
           retry_wait_seconds: {{ cookiecutter.event_gather_runner_retry_wait_seconds }}
-          command: |
+          command: >-
             cml runner \
               --single \
               --labels=gcp-cdp-runner \
@@ -46,7 +46,7 @@ jobs:
               --cloud-type=n1-standard-4 \
               --cloud-gpu=nvidia-tesla-t4 \
               --cloud-hdd-size=30 \
-              --idle-timeout=600 \
+              --idle-timeout=600
 
   process-events:
     needs: [deploy-runner-on-gcp]


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves https://github.com/CouncilDataProject/cookiecutter-cdp-deployment/issues/143

### Description of Changes

Changes `cml runner` syntax from multi-line, multi-command (`|`) to multi-line, single-command ('>-')
https://github.com/nick-fields/retry#run-multi-line-multi-command-script
