### PR TITLE
#145: bug_and_feature/pre_gen_project_hook - adding hook script to validate infrastructure_slug

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+
+# Validate the specified Google Cloud Project name is <= 30 chars
+infrastructure_slug = '{{ cookiecutter.infrastructure_slug }}'
+
+if len(infrastructure_slug) > 30:
+    print(f"ERROR: {infrastructure_slug} is not a valid Google Cloud Project name! (>30 characters)")
+    sys.exit(1)


### PR DESCRIPTION
### Link to Relevant Issue

https://github.com/CouncilDataProject/cookiecutter-cdp-deployment/issues/145

### Description of Changes

- Adds `hooks/pre_gen_project.py`
- Validates `infrastructure_slug` is <= 30 characters, the limit for Google Cloud Project names

Test by running the `cookiecutter` template and entering a very long `infrastructure_slug`; you won't see feedback until after entering all input variables, when this hook script is executed.
