### PR TITLE
#149: bug/event_gather_inputs - support default values for from and to ISO datetimes

### DIFF
--- a/{{ cookiecutter.hosting_github_repo_name }}/.github/workflows/event-gather-pipeline.yml
+++ b/{{ cookiecutter.hosting_github_repo_name }}/.github/workflows/event-gather-pipeline.yml
@@ -10,11 +10,9 @@ on:
       from:
         description: "Optional ISO formatted string for datetime to begin event gather from."
         required: false
-        default: ""  # Will get converted to N (default 2) days prior
       to:
         description: "Optional ISO formatted string for datetime to end event gather at."
         required: false
-        default: ""  # Will get converted to now
 
 permissions:
   id-token: write
@@ -102,6 +100,12 @@ jobs:
       if: {% raw %}${{ github.event_name == 'workflow_dispatch' }}{% endraw %}
       run: |
         cd python/
-        {% raw %}run_cdp_event_gather event-gather-config.json \
-          --from ${{ github.event.inputs.from }} \
-          --to ${{ github.event.inputs.to }}{% endraw %}
+        CDP_FROM_USER=${{ github.event.inputs.from }}
+        CDP_FROM_DEFAULT=$(date -Iseconds -d "2 days ago")
+        CDP_FROM=${CDP_FROM_USER:-$CDP_FROM_DEFAULT}
+        CDP_TO_USER=${{ github.event.inputs.to }}
+        CDP_TO_DEFAULT=$(date -Iseconds)
+        CDP_TO=${CDP_TO_USER:-$CDP_TO_DEFAULT}
+        run_cdp_event_gather event-gather-config.json \
+          --from $CDP_FROM \
+          --to $CDP_TO


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #149

### Description of Changes

Rather than require ISO datetimes be entered when manually calling the Event Gather action, this code generates ISO datetime values which reflect the codebase defaults (2 days prior for the from value, now for to).  Narrowly within the "Gather and Process Requested Events - Manual" step, we use the `date` command to set environment variables for the default values and use `bash` parameter expansion to override the user input when it's `null`.  This post details this approach in our specific case:
https://dev.to/mrmike/github-action-handling-input-default-value-5f2g

I ran this on the Olympia instance and the logs indicate the default values were successfully generated:

```bash
[INFO: event_gather_pipeline: 125 2023-12-03 00:50:35,612] Gathering events to process. (2023-12-01T00:50:28+00:00 - 2023-12-03T00:50:28+00:00)
```
